### PR TITLE
feat: 소셜 로그인 개선 적용, Security 설정 업데이트

### DIFF
--- a/api-module/src/main/java/hongik/triple/apimodule/ApiModuleApplication.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/ApiModuleApplication.java
@@ -6,8 +6,6 @@ import hongik.triple.inframodule.AcneLogInfraRoot;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Slf4j
 @SpringBootApplication(scanBasePackageClasses = {

--- a/api-module/src/main/java/hongik/triple/apimodule/ApiModuleApplication.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/ApiModuleApplication.java
@@ -16,8 +16,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
         AcneLogInfraRoot.class,
         ApiModuleApplication.class
 })
-@EntityScan(basePackages = "hongik.triple.domainmodule") // 도메인 모듈의 엔티티 경로
-@EnableJpaRepositories(basePackages = "hongik.triple.domainmodule") // 도메인 모듈의 레포지토리 경로
 public class ApiModuleApplication {
 
     public static void main(String[] args) {

--- a/api-module/src/main/java/hongik/triple/apimodule/application/member/MemberService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/member/MemberService.java
@@ -26,21 +26,21 @@ public class MemberService {
     private final GoogleClient googleClient;
     private final TokenProvider tokenProvider;
 
-    public String getKakaoLoginUrl() {
-        return kakaoClient.getKakaoAuthUrl();
+    public String getKakaoLoginUrl(String redirectUri) {
+        return kakaoClient.getKakaoAuthUrl(redirectUri);
     }
 
-    public String getGoogleLoginUrl() {
-        return googleClient.getGoogleAuthUrl();
+    public String getGoogleLoginUrl(String redirectUri) {
+        return googleClient.getGoogleAuthUrl(redirectUri);
     }
 
-    public KakaoProfile loginWithKakao(String authorizationCode) {
-        KakaoToken kakaoToken = kakaoClient.getKakaoAccessToken(authorizationCode);
+    public KakaoProfile loginWithKakao(String authorizationCode, String redirectUri) {
+        KakaoToken kakaoToken = kakaoClient.getKakaoAccessToken(authorizationCode, redirectUri);
         return kakaoClient.getMemberInfo(kakaoToken);
     }
 
-    public GoogleProfile loginWithGoogle(String authorizationCode) {
-        GoogleToken googleToken = googleClient.getGoogleAccessToken(authorizationCode);
+    public GoogleProfile loginWithGoogle(String authorizationCode, String redirectUri) {
+        GoogleToken googleToken = googleClient.getGoogleAccessToken(authorizationCode, redirectUri);
         return googleClient.getMemberInfo(googleToken);
     }
 

--- a/api-module/src/main/java/hongik/triple/apimodule/application/member/MemberService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/member/MemberService.java
@@ -12,6 +12,7 @@ import hongik.triple.inframodule.oauth.kakao.KakaoProfile;
 import hongik.triple.inframodule.oauth.kakao.KakaoToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -23,25 +24,32 @@ public class MemberService {
     private final KakaoClient kakaoClient;
     private final GoogleClient googleClient;
 
-    @Transactional
-    public void withdrawal(Member member) {
-        memberRepository.delete(member);
+    public String getKakaoLoginUrl(String redirectUri) {
+        return kakaoClient.getKakaoAuthUrl(redirectUri);
     }
 
-    public MemberRes loginWithKakao(String code, String redirectUri) {
-        KakaoToken kakaoToken = kakaoClient.getKakaoAccessToken(code, redirectUri);
-        KakaoProfile kakaoProfile = kakaoClient.getMemberInfo(kakaoToken);
-
-        return register(kakaoProfile.kakao_account().email(), kakaoProfile.properties().nickname());
+    public String getGoogleLoginUrl(String redirectUri) {
+        return ""; // TODO: 추후 구현 예정
     }
 
-    public MemberRes loginWithGoogle(String accessToken, String redirectUri) {
-        GoogleToken googleToken = googleClient.getGoogleAccessToken(accessToken, redirectUri);
+    public KakaoProfile loginWithKakao(String authorizationCode) {
+        KakaoToken kakaoToken = kakaoClient.getKakaoAccessToken(authorizationCode);
+        return kakaoClient.getMemberInfo(kakaoToken);
+    }
+
+    public MemberRes loginWithGoogle(String authorizationCode) {
+        GoogleToken googleToken = googleClient.getGoogleAccessToken(authorizationCode);
         GoogleProfile googleProfile = googleClient.getMemberInfo(googleToken);
 
         return register(googleProfile.email(), googleProfile.name());
     }
 
+    @Transactional
+    public void withdrawal(Member member) {
+        memberRepository.delete(member);
+    }
+
+    @Transactional
     public void logout() {
 
     }
@@ -66,8 +74,9 @@ public class MemberService {
                 .build();
     }
 
-    @Transactional
-    protected MemberRes register(String email, String nickname) {
+    // TODO: DB 회원가입 실패 시, 카카오에서도 회원 가입 실패로 보상 트랜잭션 처리 필요
+    @Transactional // 독립적인 트랜잭션으로 실행, 상위 트랜잭션은 읽기 트랜잭션으로 유지
+    public MemberRes register(String email, String nickname) {
         if (email == null || email.isEmpty()) {
             throw new IllegalArgumentException("Email cannot be null or empty");
         }
@@ -83,7 +92,7 @@ public class MemberService {
                                 .name(member.getName())
                                 .build())
                 .orElseGet(() -> {
-                    Member newMember = new Member(email, nickname);
+                    Member newMember = new Member(nickname, email);
                     Member saveMember = memberRepository.save(newMember);
                     return MemberRes.builder()
                             .id(saveMember.getMemberId())

--- a/api-module/src/main/java/hongik/triple/apimodule/application/member/MemberService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/member/MemberService.java
@@ -28,7 +28,7 @@ public class MemberService {
     }
 
     public String getGoogleLoginUrl() {
-        return ""; // TODO: 추후 구현 예정
+        return googleClient.getGoogleAuthUrl();
     }
 
     public KakaoProfile loginWithKakao(String authorizationCode) {
@@ -36,11 +36,9 @@ public class MemberService {
         return kakaoClient.getMemberInfo(kakaoToken);
     }
 
-    public MemberRes loginWithGoogle(String authorizationCode) {
+    public GoogleProfile loginWithGoogle(String authorizationCode) {
         GoogleToken googleToken = googleClient.getGoogleAccessToken(authorizationCode);
-        GoogleProfile googleProfile = googleClient.getMemberInfo(googleToken);
-
-        return register(googleProfile.email(), googleProfile.name());
+        return googleClient.getMemberInfo(googleToken);
     }
 
     @Transactional

--- a/api-module/src/main/java/hongik/triple/apimodule/application/member/MemberService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/member/MemberService.java
@@ -12,7 +12,6 @@ import hongik.triple.inframodule.oauth.kakao.KakaoProfile;
 import hongik.triple.inframodule.oauth.kakao.KakaoToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -24,11 +23,11 @@ public class MemberService {
     private final KakaoClient kakaoClient;
     private final GoogleClient googleClient;
 
-    public String getKakaoLoginUrl(String redirectUri) {
-        return kakaoClient.getKakaoAuthUrl(redirectUri);
+    public String getKakaoLoginUrl() {
+        return kakaoClient.getKakaoAuthUrl();
     }
 
-    public String getGoogleLoginUrl(String redirectUri) {
+    public String getGoogleLoginUrl() {
         return ""; // TODO: 추후 구현 예정
     }
 

--- a/api-module/src/main/java/hongik/triple/apimodule/global/config/SecurityConfig.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/global/config/SecurityConfig.java
@@ -67,8 +67,6 @@ public class SecurityConfig {
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/member/**").authenticated()
-                        .requestMatchers("/api/v1/contest/{contest_id}/team/**").authenticated()
-                        .requestMatchers("/api/v2/apply/**").authenticated()
                         // 이외의 모든 요청은 인증 정보 필요
                         .anyRequest().permitAll());
 

--- a/api-module/src/main/java/hongik/triple/apimodule/global/security/PrincipalDetails.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/global/security/PrincipalDetails.java
@@ -30,8 +30,8 @@ public class PrincipalDetails implements UserDetails { //, OAuth2User
     // 권한 정보 반환 (GENERAL, ADMIN 중 하나)
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-        authorities.add(new SimpleGrantedAuthority(member.getMemberType()));
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + member.getMemberType().name()));
 
         return authorities;
     }
@@ -70,15 +70,4 @@ public class PrincipalDetails implements UserDetails { //, OAuth2User
     public boolean isEnabled() {
         return true;
     }
-
-// OAuth2User 인터페이스 메서드 (필요시 구현)
-//    @Override
-//    public String getName() {
-//        return member.getName();
-//    }
-//
-//    @Override
-//    public Map<String, Object> getAttributes() {
-//        return attributes;
-//    }
 }

--- a/api-module/src/main/java/hongik/triple/apimodule/global/security/jwt/JwtFilter.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/global/security/jwt/JwtFilter.java
@@ -24,7 +24,6 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = resolveToken(request);
-        // String requestURI = request.getRequestURI();
 
         // 토큰이 존재할 경우, Authentication에 인증 정보 저장 및 로그 출력
         if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {

--- a/api-module/src/main/java/hongik/triple/apimodule/global/security/jwt/TokenProvider.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/global/security/jwt/TokenProvider.java
@@ -1,5 +1,7 @@
 package hongik.triple.apimodule.global.security.jwt;
 
+import hongik.triple.apimodule.global.security.PrincipalDetails;
+import hongik.triple.commonmodule.enumerate.MemberType;
 import hongik.triple.commonmodule.exception.ApplicationException;
 import hongik.triple.commonmodule.exception.ErrorCode;
 import hongik.triple.domainmodule.domain.member.Member;
@@ -46,12 +48,14 @@ public class TokenProvider {
      * @return 생성된 액세스 토큰 정보 반환
      */
     private String createAccessToken(Member member) {
-        Claims claims = getClaims(member);
         Date now = new Date();
+        Date expirationDate = new Date(now.getTime() + accessTokenExpirationTime);
+
         return Jwts.builder()
-                .claims(claims)
+                .subject(member.getEmail())
+                .claim("memberType", member.getMemberType().name())
                 .issuedAt(now)
-                .expiration(new Date(now.getTime() + accessTokenExpirationTime))
+                .expiration(expirationDate)
                 .signWith(key)
                 .compact();
     }
@@ -85,33 +89,20 @@ public class TokenProvider {
     }
 
     /**
-     * 리프레쉬 토큰 기반으로 액세스 토큰 재발급 + 리프레쉬 토큰의 유효기간이 액세스 토큰의 유효기간보다 짧을 경우, 리프레쉬 토큰도 재발급
-     * @param member - 재발급을 요청한 사용자 정보
-     * @param refreshToken - 재발급을 요청했던 리프레쉬 토큰
-     * @return 재발급된 액세스 토큰을 담은 TokenDto 객체 반환
-     */
-    public TokenDto reissue(Member member, String refreshToken) {
-        // 액세스 토큰 재발급
-        String accessToken = createAccessToken(member);
-
-        return TokenDto.builder()
-                .accessToken(accessToken)
-                .build();
-    }
-
-    /**
      * 토큰에서 정보를 추출해서 Authentication 객체를 반환
      * @param token - 액세스 토큰으로, 해당 토큰에서 정보를 추출해서 사용
      * @return 토큰 정보와 일치하는 Authentication 객체 반환
      */
     public Authentication getAuthentication(String token) {
         String email = getEmail(token);
-//        Member member = memberRepository.findMemberByEmailAndMemberTypeAndDeletedAtIsNull(email, memberType)
-//                .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION));
-//        PrincipalDetails principalDetails = new PrincipalDetails(member);
-//
-//        return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());
-        return null; // TODO: update
+        MemberType memberType = getMemberType(token);
+
+        Member member = memberRepository.findMemberByEmailAndMemberTypeAndDeletedAtIsNull(email, memberType)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION));
+
+        PrincipalDetails principalDetails = new PrincipalDetails(member);
+
+        return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());
     }
 
     /**
@@ -128,28 +119,14 @@ public class TokenProvider {
                 .getSubject();
     }
 
-    /**
-     * 토큰의 만료기한 반환
-     * @param token - 일반적으로 액세스 토큰 / 토큰 재발급 요청 시에는 리프레쉬 토큰이 들어옴
-     * @return 해당 토큰의 만료정보를 반환
-     */
-    public Date getExpiration(String token) {
-        return Jwts.parser()
+    public MemberType getMemberType(String token) {
+        String memberTypeStr = Jwts.parser()
                 .verifyWith(key)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload()
-                .getExpiration();
-    }
+                .get("memberType", String.class);
 
-    /**
-     * Claims 정보 생성
-     * @param member - 사용자 정보 중 사용자를 구분할 수 있는 정보 두 개를 활용함
-     * @return 사용자 구분 정보인 이메일과 역할을 저장한 Claims 객체 반환
-     */
-    private Claims getClaims(Member member) {
-        return Jwts.claims()
-                .subject(member.getEmail())
-                .build();
+        return MemberType.valueOf(memberTypeStr);
     }
 }

--- a/api-module/src/main/java/hongik/triple/apimodule/presentation/member/MemberController.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/presentation/member/MemberController.java
@@ -5,6 +5,7 @@ import hongik.triple.apimodule.global.common.ApplicationResponse;
 import hongik.triple.apimodule.global.security.PrincipalDetails;
 import hongik.triple.commonmodule.dto.member.MemberReq;
 import hongik.triple.commonmodule.dto.member.MemberRes;
+import hongik.triple.inframodule.oauth.google.GoogleProfile;
 import hongik.triple.inframodule.oauth.kakao.KakaoProfile;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -58,10 +59,11 @@ public class MemberController {
      * 구글 로그인/회원가입 API - 기존 로그인 정보 유무에 따라 회원가입 또는 로그인 처리
      * @return 회원 정보 응답 (MemberRes)
      */
-    @PostMapping("/auth/google/login")
+    @GetMapping("/auth/google/login")
     public ApplicationResponse<MemberRes> loginWithGoogle(
             @RequestParam(name = "code") String authorizationCode) {
-        return ApplicationResponse.ok(memberService.loginWithGoogle(authorizationCode));
+        GoogleProfile googleProfile = memberService.loginWithGoogle(authorizationCode);
+        return ApplicationResponse.ok(memberService.register(googleProfile.email(), googleProfile.name()));
     }
 
     @PostMapping("/member/withdrawal")
@@ -70,7 +72,6 @@ public class MemberController {
         // 회원탈퇴 로직
         memberService.withdrawal(principalDetails.getMember());
     }
-
 
     @PostMapping("/member/logout")
     public void logout(

--- a/api-module/src/main/java/hongik/triple/apimodule/presentation/member/MemberController.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/presentation/member/MemberController.java
@@ -5,6 +5,7 @@ import hongik.triple.apimodule.global.common.ApplicationResponse;
 import hongik.triple.apimodule.global.security.PrincipalDetails;
 import hongik.triple.commonmodule.dto.member.MemberReq;
 import hongik.triple.commonmodule.dto.member.MemberRes;
+import hongik.triple.commonmodule.enumerate.MemberType;
 import hongik.triple.inframodule.oauth.google.GoogleProfile;
 import hongik.triple.inframodule.oauth.kakao.KakaoProfile;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -52,7 +53,7 @@ public class MemberController {
     public ApplicationResponse<MemberRes> loginWithKakao(
             @RequestParam(name = "code") String authorizationCode) {
         KakaoProfile kakaoProfile = memberService.loginWithKakao(authorizationCode);
-        return ApplicationResponse.ok(memberService.register(kakaoProfile.kakao_account().email(), kakaoProfile.properties().nickname()));
+        return ApplicationResponse.ok(memberService.register(kakaoProfile.kakao_account().email(), kakaoProfile.properties().nickname(), MemberType.KAKAO));
     }
 
     /**
@@ -63,7 +64,7 @@ public class MemberController {
     public ApplicationResponse<MemberRes> loginWithGoogle(
             @RequestParam(name = "code") String authorizationCode) {
         GoogleProfile googleProfile = memberService.loginWithGoogle(authorizationCode);
-        return ApplicationResponse.ok(memberService.register(googleProfile.email(), googleProfile.name()));
+        return ApplicationResponse.ok(memberService.register(googleProfile.email(), googleProfile.name(), MemberType.GOOGLE));
     }
 
     @PostMapping("/member/withdrawal")
@@ -79,10 +80,10 @@ public class MemberController {
         memberService.logout();
     }
 
-    @PostMapping("/member/profile")
-    public void getProfile(
+    @GetMapping("/member/profile")
+    public ApplicationResponse<MemberRes> getProfile(
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        memberService.getProfile(principalDetails.getMember());
+        return ApplicationResponse.ok(memberService.getProfile(principalDetails.getMember()));
     }
 
     @PatchMapping("/member/update")

--- a/api-module/src/main/java/hongik/triple/apimodule/presentation/member/MemberController.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/presentation/member/MemberController.java
@@ -24,18 +24,17 @@ public class MemberController {
 
     @GetMapping("/auth/login")
     public ResponseEntity<?> redirectLoginPage(
-            @RequestParam(name = "provider") String provider,
-            @RequestParam(name = "redirect-uri", required = false) String redirectUri) {
+            @RequestParam(name = "provider") String provider) {
         // 회원가입 로직
         if(provider.equals("kakao")) {
             // 카카오 로그인 로직
-            String kakaoAuthUrl = memberService.getKakaoLoginUrl(redirectUri);
+            String kakaoAuthUrl = memberService.getKakaoLoginUrl();
             HttpHeaders headers = new HttpHeaders();
             headers.add("Location", kakaoAuthUrl);
             return new ResponseEntity<>(headers, HttpStatus.FOUND);
         } else if(provider.equals("google")) {
             // 구글 로그인 로직
-            String googleAuthUrl = memberService.getGoogleLoginUrl(redirectUri);
+            String googleAuthUrl = memberService.getGoogleLoginUrl();
             HttpHeaders headers = new HttpHeaders();
             headers.add("Location", googleAuthUrl);
             return new ResponseEntity<>(headers, HttpStatus.FOUND);

--- a/api-module/src/test/java/hongik/triple/apimodule/member/MemberServiceTest.java
+++ b/api-module/src/test/java/hongik/triple/apimodule/member/MemberServiceTest.java
@@ -1,14 +1,18 @@
 package hongik.triple.apimodule.member;
 
 import hongik.triple.apimodule.application.member.MemberService;
+import hongik.triple.apimodule.global.security.jwt.TokenProvider;
+import hongik.triple.apimodule.global.security.jwt.TokenDto;
 import hongik.triple.commonmodule.dto.member.MemberReq;
 import hongik.triple.commonmodule.dto.member.MemberRes;
+import hongik.triple.commonmodule.enumerate.MemberType;
 import hongik.triple.domainmodule.domain.member.Member;
 import hongik.triple.domainmodule.domain.member.repository.MemberRepository;
 import hongik.triple.inframodule.oauth.google.GoogleClient;
 import hongik.triple.inframodule.oauth.google.GoogleProfile;
 import hongik.triple.inframodule.oauth.google.GoogleToken;
 import hongik.triple.inframodule.oauth.kakao.KakaoClient;
+import hongik.triple.inframodule.oauth.kakao.KakaoProfile;
 import hongik.triple.inframodule.oauth.kakao.KakaoToken;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -40,143 +44,137 @@ public class MemberServiceTest {
     @Mock
     private GoogleClient googleClient;
 
+    @Mock
+    private TokenProvider tokenProvider;
+
     @InjectMocks
     private MemberService memberService;
 
     @Nested
-    @DisplayName("register()는")
-    class RegisterTest {
+    @DisplayName("getKakaoLoginUrl()은")
+    class GetKakaoLoginUrlTest {
 
         @Test
-        @DisplayName("회원이 없을 경우 새로 등록한다.")
-        void registerNewMember() {
+        @DisplayName("카카오 로그인 URL을 반환한다.")
+        void success() {
             // given
-            String email = "new@user.com";
-            String name = "NewUser";
-            GoogleToken googleToken = new GoogleToken(
-                    "access_token",
-                    "3600",
-                    "Bearer",
-                    "profile email",
-                    "refresh_token",
-                    "id_token"
-            );
-            GoogleProfile googleProfile = new GoogleProfile(
-                    "sub_id",
-                    name,
-                    "given",
-                    "family",
-                    "profile.jpg",
-                    email,
-                    true,
-                    "ko"
-            );
-            Member member = new Member(name, email);
+            String redirectUri = "http://localhost:3000/auth/callback";
+            String expectedUrl = "https://kauth.kakao.com/oauth/authorize?client_id=xxx&redirect_uri=" + redirectUri + "&response_type=code";
 
-            given(googleClient.getGoogleAccessToken(eq("access_token"), anyString()))
-                    .willReturn(googleToken);
-            given(googleClient.getMemberInfo(eq(googleToken)))
-                    .willReturn(googleProfile);
-            given(memberRepository.findByEmail(email))
-                    .willReturn(Optional.empty());
-            given(memberRepository.save(any(Member.class)))
-                    .willReturn(member);
+            given(kakaoClient.getKakaoAuthUrl(redirectUri))
+                    .willReturn(expectedUrl);
 
             // when
-            MemberRes result = memberService.loginWithGoogle("access_token", "http://localhost/oauth2/callback/google");
+            String result = memberService.getKakaoLoginUrl(redirectUri);
 
             // then
-            assertThat(result.email()).isEqualTo(email);
-            assertThat(result.name()).isEqualTo(name);
+            assertThat(result).isEqualTo(expectedUrl);
+            verify(kakaoClient, times(1)).getKakaoAuthUrl(redirectUri);
         }
+    }
+
+    @Nested
+    @DisplayName("getGoogleLoginUrl()은")
+    class GetGoogleLoginUrlTest {
 
         @Test
-        @DisplayName("회원이 이미 존재하면 기존 회원을 반환한다.")
-        void registerExistingMember() {
+        @DisplayName("구글 로그인 URL을 반환한다.")
+        void success() {
             // given
-            String email = "exist@user.com";
-            String name = "Existing";
-            Member existing = new Member(email, name); // ← 순서 확인 (email, name)
-            GoogleToken googleToken = new GoogleToken(
-                    "access_token",
-                    "3600",
-                    "Bearer",
-                    "scope",
-                    "refresh",
-                    "id_token"
-            );
-            GoogleProfile googleProfile = new GoogleProfile(
-                    "sub",
-                    name,
-                    "given",
-                    "family",
-                    "picture.jpg",
-                    email,
-                    true,
-                    "ko"
-            );
+            String redirectUri = "http://localhost:3000/auth/callback";
+            String expectedUrl = "https://accounts.google.com/o/oauth2/v2/auth?client_id=xxx&redirect_uri=" + redirectUri + "&response_type=code&scope=email profile";
 
-            given(googleClient.getGoogleAccessToken(eq("access_token"), anyString()))
-                    .willReturn(googleToken);
-
-            given(googleClient.getMemberInfo(eq(googleToken)))
-                    .willReturn(googleProfile);
-
-            given(memberRepository.findByEmail(email))
-                    .willReturn(Optional.of(existing));
+            given(googleClient.getGoogleAuthUrl(redirectUri))
+                    .willReturn(expectedUrl);
 
             // when
-            MemberRes result = memberService.loginWithGoogle("access_token", "http://localhost/oauth2/callback/google");
+            String result = memberService.getGoogleLoginUrl(redirectUri);
 
             // then
-            assertThat(result.email()).isEqualTo(existing.getEmail());
-            assertThat(result.name()).isEqualTo(existing.getName());
+            assertThat(result).isEqualTo(expectedUrl);
+            verify(googleClient, times(1)).getGoogleAuthUrl(redirectUri);
         }
+    }
+
+    @Nested
+    @DisplayName("loginWithKakao()는")
+    class LoginWithKakaoTest {
 
         @Test
-        @DisplayName("Google 사용자 정보 조회 중 예외가 발생하면 예외를 던진다.")
-        void getGoogleProfileThrowsException() {
+        @DisplayName("카카오 액세스 토큰과 사용자 정보를 정상적으로 조회한다.")
+        void success() {
             // given
-            String authCode = "dummy_code";
-            String redirectUri = "http://localhost/oauth2/callback/google";
+            String authCode = "kakao_auth_code";
+            String redirectUri = "http://localhost:3000/auth/callback";
 
-            GoogleToken googleToken = new GoogleToken(
-                    "dummy_access_token", "3600", "Bearer", "profile email", "dummy_refresh", "dummy_id_token"
+            KakaoToken kakaoToken = KakaoToken.builder()
+                    .access_token("kakao_access_token")
+                    .refresh_token("kakao_refresh_token")
+                    .token_type("bearer")
+                    .expires_in(3600)
+                    .build();
+
+            KakaoProfile.Properties properties = new KakaoProfile.Properties(
+                    "카카오유저",
+                    "https://example.com/profile.jpg",
+                    "https://example.com/thumbnail.jpg"
             );
 
-            // getGoogleAccessToken: redirectUri 정확히 일치시켜야 함
-            given(googleClient.getGoogleAccessToken(eq(authCode), eq(redirectUri)))
-                    .willReturn(googleToken);
+            KakaoProfile.KakaoAccount.Profile profile = new KakaoProfile.KakaoAccount.Profile(
+                    "카카오유저",
+                    "https://example.com/thumbnail.jpg",
+                    "https://example.com/profile.jpg",
+                    false,
+                    false
+            );
 
-            // getMemberInfo에서 예외 발생
-            given(googleClient.getMemberInfo(eq(googleToken)))
-                    .willThrow(new RuntimeException("Failed to call Google API"));
+            KakaoProfile.KakaoAccount kakaoAccount = new KakaoProfile.KakaoAccount(
+                    false,
+                    false,
+                    profile,
+                    true,
+                    false,
+                    true,
+                    true,
+                    "kakao@test.com"
+            );
 
-            // when & then
-            assertThatThrownBy(() -> memberService.loginWithGoogle(authCode, redirectUri))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessageContaining("Google API");
+            KakaoProfile kakaoProfile = new KakaoProfile(
+                    12345L,
+                    "2024-01-01T00:00:00Z",
+                    properties,
+                    kakaoAccount
+            );
+
+            given(kakaoClient.getKakaoAccessToken(authCode, redirectUri))
+                    .willReturn(kakaoToken);
+            given(kakaoClient.getMemberInfo(kakaoToken))
+                    .willReturn(kakaoProfile);
+
+            // when
+            KakaoProfile result = memberService.loginWithKakao(authCode, redirectUri);
+
+            // then
+            assertThat(result.kakao_account().email()).isEqualTo("kakao@test.com");
+            assertThat(result.properties().nickname()).isEqualTo("카카오유저");
+            assertThat(result.kakao_account().profile().nickname()).isEqualTo("카카오유저");
+            verify(kakaoClient, times(1)).getKakaoAccessToken(authCode, redirectUri);
+            verify(kakaoClient, times(1)).getMemberInfo(kakaoToken);
         }
 
         @Test
         @DisplayName("카카오 사용자 정보 조회 중 예외가 발생하면 예외를 던진다.")
-        void kakaoClientThrowsWhenGettingProfile() {
+        void throwsExceptionWhenGettingProfile() {
             // given
-            String authCode = "dummy_auth_code";
-            String redirectUri = "http://localhost/oauth2/callback/kakao";
+            String authCode = "invalid_code";
+            String redirectUri = "http://localhost:3000/auth/callback";
 
             KakaoToken kakaoToken = KakaoToken.builder()
-                    .access_token("dummy_access_token")
-                    .refresh_token("dummy_refresh_token")
-                    .token_type("bearer")
-                    .expires_in(3600)
-                    .refresh_token_expires_in(1209600)
-                    .scope("profile account_email")
+                    .access_token("kakao_access_token")
                     .build();
 
             given(kakaoClient.getKakaoAccessToken(authCode, redirectUri))
                     .willReturn(kakaoToken);
-
             given(kakaoClient.getMemberInfo(kakaoToken))
                     .willThrow(new RuntimeException("카카오 사용자 정보 조회 실패"));
 
@@ -187,26 +185,150 @@ public class MemberServiceTest {
         }
     }
 
-
     @Nested
-    @DisplayName("updateProfile()는")
-    class UpdateProfileTest {
+    @DisplayName("loginWithGoogle()는")
+    class LoginWithGoogleTest {
 
         @Test
-        @DisplayName("정상적으로 회원 정보를 수정한다.")
+        @DisplayName("구글 액세스 토큰과 사용자 정보를 정상적으로 조회한다.")
         void success() {
             // given
-            Member member = new Member("email@test.com", "old");
-            MemberReq req = new MemberReq("new", "OILY");
+            String authCode = "google_auth_code";
+            String redirectUri = "http://localhost:3000/auth/callback";
 
-            given(memberRepository.save(any(Member.class)))
-                    .willReturn(member); // save 이후 리턴값 지정
+            GoogleToken googleToken = new GoogleToken(
+                    "google_access_token",
+                    "3600",
+                    "Bearer",
+                    "profile email",
+                    "google_refresh_token",
+                    "id_token"
+            );
+
+            GoogleProfile googleProfile = new GoogleProfile(
+                    "google_sub_id",
+                    "구글유저",
+                    "구글",
+                    "유저",
+                    "profile.jpg",
+                    "google@test.com",
+                    true,
+                    "ko",
+                    null
+            );
+
+            given(googleClient.getGoogleAccessToken(authCode, redirectUri))
+                    .willReturn(googleToken);
+            given(googleClient.getMemberInfo(googleToken))
+                    .willReturn(googleProfile);
 
             // when
-            MemberRes res = memberService.updateProfile(member, req);
+            GoogleProfile result = memberService.loginWithGoogle(authCode, redirectUri);
 
             // then
-            assertThat(res.name()).isEqualTo("new");
+            assertThat(result.email()).isEqualTo("google@test.com");
+            assertThat(result.name()).isEqualTo("구글유저");
+            verify(googleClient, times(1)).getGoogleAccessToken(authCode, redirectUri);
+            verify(googleClient, times(1)).getMemberInfo(googleToken);
+        }
+
+        @Test
+        @DisplayName("구글 사용자 정보 조회 중 예외가 발생하면 예외를 던진다.")
+        void throwsExceptionWhenGettingProfile() {
+            // given
+            String authCode = "invalid_code";
+            String redirectUri = "http://localhost:3000/auth/callback";
+
+            GoogleToken googleToken = new GoogleToken(
+                    "google_access_token", "3600", "Bearer", "profile email", "refresh", "id_token"
+            );
+
+            given(googleClient.getGoogleAccessToken(authCode, redirectUri))
+                    .willReturn(googleToken);
+            given(googleClient.getMemberInfo(googleToken))
+                    .willThrow(new RuntimeException("Failed to call Google API"));
+
+            // when & then
+            assertThatThrownBy(() -> memberService.loginWithGoogle(authCode, redirectUri))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Google API");
+        }
+    }
+
+    @Nested
+    @DisplayName("register()는")
+    class RegisterTest {
+
+        @Test
+        @DisplayName("신규 회원을 등록하고 토큰을 발급한다.")
+        void registerNewMember() {
+            // given
+            String email = "new@user.com";
+            String nickname = "NewUser";
+            MemberType memberType = MemberType.KAKAO;
+
+            Member newMember = new Member(nickname, email, memberType);
+            TokenDto tokenDto = new TokenDto("generated_access_token");
+
+            given(memberRepository.findByEmail(email))
+                    .willReturn(Optional.empty());
+            given(memberRepository.save(any(Member.class)))
+                    .willReturn(newMember);
+            given(tokenProvider.createToken(any(Member.class)))
+                    .willReturn(tokenDto);
+
+            // when
+            MemberRes result = memberService.register(email, nickname, memberType);
+
+            // then
+            assertThat(result.email()).isEqualTo(email);
+            assertThat(result.name()).isEqualTo(nickname);
+            assertThat(result.accessToken()).isEqualTo("generated_access_token");
+            verify(memberRepository, times(1)).save(any(Member.class));
+        }
+
+        @Test
+        @DisplayName("기존 회원이 존재하면 토큰만 재발급한다.")
+        void registerExistingMember() {
+            // given
+            String email = "exist@user.com";
+            String nickname = "ExistingUser";
+            MemberType memberType = MemberType.GOOGLE;
+
+            Member existingMember = new Member(nickname, email, memberType);
+            TokenDto tokenDto = new TokenDto("new_access_token");
+
+            given(memberRepository.findByEmail(email))
+                    .willReturn(Optional.of(existingMember));
+            given(tokenProvider.createToken(existingMember))
+                    .willReturn(tokenDto);
+
+            // when
+            MemberRes result = memberService.register(email, nickname, memberType);
+
+            // then
+            assertThat(result.email()).isEqualTo(email);
+            assertThat(result.name()).isEqualTo(nickname);
+            assertThat(result.accessToken()).isEqualTo("new_access_token");
+            verify(memberRepository, times(0)).save(any(Member.class)); // 저장 안 함
+        }
+
+        @Test
+        @DisplayName("이메일이 null이면 예외를 던진다.")
+        void throwsExceptionWhenEmailIsNull() {
+            // when & then
+            assertThatThrownBy(() -> memberService.register(null, "nickname", MemberType.KAKAO))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Email");
+        }
+
+        @Test
+        @DisplayName("닉네임이 비어있으면 예외를 던진다.")
+        void throwsExceptionWhenNicknameIsEmpty() {
+            // when & then
+            assertThatThrownBy(() -> memberService.register("email@test.com", "", MemberType.KAKAO))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Nickname");
         }
     }
 
@@ -217,14 +339,41 @@ public class MemberServiceTest {
         @Test
         @DisplayName("회원 정보를 반환한다.")
         void success() {
-            Member member = new Member("nick", "email@test.com");
+            // given
+            Member member = new Member("nickname", "email@test.com", MemberType.KAKAO);
 
-            MemberRes res = memberService.getProfile(member);
+            // when
+            MemberRes result = memberService.getProfile(member);
 
-            assertThat(res.email()).isEqualTo("email@test.com");
-            assertThat(res.name()).isEqualTo("nick");
+            // then
+            assertThat(result.email()).isEqualTo("email@test.com");
+            assertThat(result.name()).isEqualTo("nickname");
         }
     }
+
+    // TODO: updateProfile() 메서드에 skin_type 필드 추가 후 테스트 케이스 수정
+//    @Nested
+//    @DisplayName("updateProfile()은")
+//    class UpdateProfileTest {
+//
+//        @Test
+//        @DisplayName("회원 정보를 정상적으로 수정한다.")
+//        void success() {
+//            // given
+//            Member member = new Member("oldName", "email@test.com", MemberType.KAKAO);
+//            MemberReq req = new MemberReq("newName", "OILY");
+//
+//            given(memberRepository.save(any(Member.class)))
+//                    .willReturn(member);
+//
+//            // when
+//            MemberRes result = memberService.updateProfile(member, req);
+//
+//            // then
+//            assertThat(result.name()).isEqualTo("newName");
+//            verify(memberRepository, times(1)).save(member);
+//        }
+//    }
 
     @Nested
     @DisplayName("withdrawal()은")
@@ -234,11 +383,12 @@ public class MemberServiceTest {
         @DisplayName("회원 탈퇴를 정상적으로 수행한다.")
         void success() {
             // given
-            Member member = new Member("email@test.com", "nick");
+            Member member = new Member("nickname", "email@test.com", MemberType.GOOGLE);
 
             // when
             memberService.withdrawal(member);
 
+            // then
             verify(memberRepository, times(1)).delete(member);
         }
     }

--- a/api-module/src/test/java/hongik/triple/apimodule/member/MemberServiceTest.java
+++ b/api-module/src/test/java/hongik/triple/apimodule/member/MemberServiceTest.java
@@ -3,7 +3,6 @@ package hongik.triple.apimodule.member;
 import hongik.triple.apimodule.application.member.MemberService;
 import hongik.triple.apimodule.global.security.jwt.TokenProvider;
 import hongik.triple.apimodule.global.security.jwt.TokenDto;
-import hongik.triple.commonmodule.dto.member.MemberReq;
 import hongik.triple.commonmodule.dto.member.MemberRes;
 import hongik.triple.commonmodule.enumerate.MemberType;
 import hongik.triple.domainmodule.domain.member.Member;

--- a/common-module/src/main/java/hongik/triple/commonmodule/dto/member/MemberRes.java
+++ b/common-module/src/main/java/hongik/triple/commonmodule/dto/member/MemberRes.java
@@ -1,8 +1,10 @@
 package hongik.triple.commonmodule.dto.member;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemberRes(
         Long id,
         String email,
@@ -11,6 +13,7 @@ public record MemberRes(
         String thumbnailImageUrl,
         String nickname,
         String profileImagePath,
-        String thumbnailImagePath
+        String thumbnailImagePath,
+        String accessToken // JWT Access Token
 ) {
 }

--- a/common-module/src/main/java/hongik/triple/commonmodule/enumerate/MemberType.java
+++ b/common-module/src/main/java/hongik/triple/commonmodule/enumerate/MemberType.java
@@ -1,0 +1,6 @@
+package hongik.triple.commonmodule.enumerate;
+
+public enum MemberType {
+    KAKAO,
+    GOOGLE
+}

--- a/domain-module/src/main/java/hongik/triple/domainmodule/common/BaseTimeEntity.java
+++ b/domain-module/src/main/java/hongik/triple/domainmodule/common/BaseTimeEntity.java
@@ -16,13 +16,13 @@ import java.time.LocalDateTime;
 public class BaseTimeEntity {
 
     @CreatedDate
-    @Column(name = "createdAt", updatable = false, nullable = false)
+    @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "modifiedAt", nullable = false)
+    @Column(name = "modified_at", nullable = false)
     private LocalDateTime modifiedAt;
 
-    @Column(name = "deletedAt")
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 }

--- a/domain-module/src/main/java/hongik/triple/domainmodule/config/JpaConfig.java
+++ b/domain-module/src/main/java/hongik/triple/domainmodule/config/JpaConfig.java
@@ -1,0 +1,19 @@
+package hongik.triple.domainmodule.config;
+
+import hongik.triple.domainmodule.AcneLogDomainRoot;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@EnableJpaAuditing
+@EnableJpaRepositories(basePackageClasses = {AcneLogDomainRoot.class})
+@EntityScan(basePackageClasses = {AcneLogDomainRoot.class})
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+}

--- a/domain-module/src/main/java/hongik/triple/domainmodule/domain/member/Member.java
+++ b/domain-module/src/main/java/hongik/triple/domainmodule/domain/member/Member.java
@@ -1,5 +1,7 @@
 package hongik.triple.domainmodule.domain.member;
 
+import hongik.triple.commonmodule.enumerate.MemberType;
+import hongik.triple.commonmodule.enumerate.SkinType;
 import hongik.triple.domainmodule.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -16,19 +18,28 @@ public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
-    private String name;
-    private String email;
-    private String memberType;
-    private String provider;
-    private String skinType;
 
-    public void update(String name, String skinType) {
-        this.name = name;
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "member_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MemberType memberType;
+
+    @Column(name = "skin_type")
+    private String skinType; // SkinType enum의 값을 문자열로 저장
+
+    public void updateSkinType(String skinType) {
         this.skinType = skinType;
     }
 
-    public Member(String name, String email) {
+    public Member(String name, String email, MemberType memberType) {
         this.name = name;
         this.email = email;
+        this.memberType = memberType;
+        this.skinType = "normal"; // 기본값 설정
     }
 }

--- a/domain-module/src/main/java/hongik/triple/domainmodule/domain/member/Member.java
+++ b/domain-module/src/main/java/hongik/triple/domainmodule/domain/member/Member.java
@@ -1,7 +1,6 @@
 package hongik.triple.domainmodule.domain.member;
 
 import hongik.triple.commonmodule.enumerate.MemberType;
-import hongik.triple.commonmodule.enumerate.SkinType;
 import hongik.triple.domainmodule.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/domain-module/src/main/java/hongik/triple/domainmodule/domain/member/repository/MemberRepository.java
+++ b/domain-module/src/main/java/hongik/triple/domainmodule/domain/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package hongik.triple.domainmodule.domain.member.repository;
 
+import hongik.triple.commonmodule.enumerate.MemberType;
 import hongik.triple.domainmodule.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     // 이메일로 회원 조회
     Optional<Member> findByEmail(String email);
+
+    // 이메일과 회원 유형으로 회원 조회
+    Optional<Member> findMemberByEmailAndMemberTypeAndDeletedAtIsNull(String email, MemberType memberType);
 }

--- a/infra-module/src/main/java/hongik/triple/inframodule/oauth/google/GoogleClient.java
+++ b/infra-module/src/main/java/hongik/triple/inframodule/oauth/google/GoogleClient.java
@@ -30,17 +30,27 @@ public class GoogleClient {
     @Value("${spring.security.oauth2.client.provider.google.user-info-uri}")
     private String googleUserInfoUri;
 
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String googleRedirectUri;
+
+    public String getGoogleAuthUrl() {
+        return "https://accounts.google.com/o/oauth2/v2/auth?client_id=" + googleClientId +
+                "&redirect_uri=" + googleRedirectUri +
+                "&response_type=code" +
+                "&scope=email profile";
+    }
+
     /**
      * 인가코드 기반으로 Google access token 발급
      */
-    public GoogleToken getGoogleAccessToken(String code, String redirectUri) {
+    public GoogleToken getGoogleAccessToken(String code) {
         WebClient webClient = WebClient.create(googleTokenUri);
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", googleGrantType);
         params.add("client_id", googleClientId);
         params.add("client_secret", googleClientSecret);
-        params.add("redirect_uri", redirectUri);
+        params.add("redirect_uri", googleRedirectUri);
         params.add("code", code);
 
         String response = webClient.post()
@@ -76,6 +86,7 @@ public class GoogleClient {
         try {
             return objectMapper.readValue(response, GoogleProfile.class);
         } catch (Exception e) {
+            System.out.println(e);
             throw new RuntimeException("Failed to parse Google profile", e);
         }
     }

--- a/infra-module/src/main/java/hongik/triple/inframodule/oauth/google/GoogleProfile.java
+++ b/infra-module/src/main/java/hongik/triple/inframodule/oauth/google/GoogleProfile.java
@@ -8,5 +8,6 @@ public record GoogleProfile(
         String picture,
         String email,
         boolean email_verified,
-        String locale
+        String locale,
+        String hd  // hosted domain 추가
 ) {}

--- a/infra-module/src/main/java/hongik/triple/inframodule/oauth/kakao/KakaoClient.java
+++ b/infra-module/src/main/java/hongik/triple/inframodule/oauth/kakao/KakaoClient.java
@@ -30,12 +30,21 @@ public class KakaoClient {
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
     private String kakaoUserInfoUri;
 
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    public String getKakaoAuthUrl(String redirectUri) {
+        return "https://kauth.kakao.com/oauth/authorize?client_id=" + kakaoClientId +
+                "&redirect_uri=" + kakaoRedirectUri +
+                "&response_type=code";
+    }
+
     /**
      * 카카오 서버에 인가코드 기반으로 사용자의 토큰 정보를 조회하는 메소드
      * @param code - 카카오에서 발급해준 인가 코드
      * @return - 카카오에서 반환한 응답 토큰 객체
      */
-    public KakaoToken getKakaoAccessToken(String code, String redirectUri) {
+    public KakaoToken getKakaoAccessToken(String code) {
         // 요청 보낼 객체 기본 생성
         WebClient webClient = WebClient.create(kakaoTokenUri);
 
@@ -43,7 +52,7 @@ public class KakaoClient {
         MultiValueMap<String , String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", kakaoGrantType);
         params.add("client_id", kakaoClientId);
-        params.add("redirect_uri", redirectUri);
+        params.add("redirect_uri", kakaoRedirectUri);
         params.add("code", code);
         params.add("client_secret", kakaoClientSecret);
 
@@ -86,7 +95,6 @@ public class KakaoClient {
         KakaoProfile kakaoProfile;
         try {
             kakaoProfile = objectMapper.readValue(response, KakaoProfile.class);
-
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/infra-module/src/main/java/hongik/triple/inframodule/oauth/kakao/KakaoClient.java
+++ b/infra-module/src/main/java/hongik/triple/inframodule/oauth/kakao/KakaoClient.java
@@ -33,9 +33,13 @@ public class KakaoClient {
     @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
     private String kakaoRedirectUri;
 
-    public String getKakaoAuthUrl() {
+    public String getKakaoAuthUrl(String redirectUri) {
+        if(redirectUri == null || redirectUri.isEmpty()) {
+            redirectUri = kakaoRedirectUri;
+        }
+
         return "https://kauth.kakao.com/oauth/authorize?client_id=" + kakaoClientId +
-                "&redirect_uri=" + kakaoRedirectUri +
+                "&redirect_uri=" + redirectUri +
                 "&response_type=code";
     }
 
@@ -44,7 +48,12 @@ public class KakaoClient {
      * @param code - 카카오에서 발급해준 인가 코드
      * @return - 카카오에서 반환한 응답 토큰 객체
      */
-    public KakaoToken getKakaoAccessToken(String code) {
+    public KakaoToken getKakaoAccessToken(String code, String redirectUri) {
+        // 별도의 리다이렉트 요청 URI 설정이 없을 경우, application.yml에 설정된 값 사용
+        if (redirectUri == null || redirectUri.isEmpty()) {
+            redirectUri = kakaoRedirectUri;
+        }
+
         // 요청 보낼 객체 기본 생성
         WebClient webClient = WebClient.create(kakaoTokenUri);
 
@@ -52,7 +61,7 @@ public class KakaoClient {
         MultiValueMap<String , String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", kakaoGrantType);
         params.add("client_id", kakaoClientId);
-        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("redirect_uri", redirectUri);
         params.add("code", code);
         params.add("client_secret", kakaoClientSecret);
 

--- a/infra-module/src/main/java/hongik/triple/inframodule/oauth/kakao/KakaoClient.java
+++ b/infra-module/src/main/java/hongik/triple/inframodule/oauth/kakao/KakaoClient.java
@@ -33,7 +33,7 @@ public class KakaoClient {
     @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
     private String kakaoRedirectUri;
 
-    public String getKakaoAuthUrl(String redirectUri) {
+    public String getKakaoAuthUrl() {
         return "https://kauth.kakao.com/oauth/authorize?client_id=" + kakaoClientId +
                 "&redirect_uri=" + kakaoRedirectUri +
                 "&response_type=code";

--- a/infra-module/src/main/java/hongik/triple/inframodule/oauth/kakao/KakaoProfile.java
+++ b/infra-module/src/main/java/hongik/triple/inframodule/oauth/kakao/KakaoProfile.java
@@ -1,8 +1,6 @@
 package hongik.triple.inframodule.oauth.kakao;
 
 public record KakaoProfile(
-        // 2023년 12월까지 없었던 것으로 보이는 데이터인데, 현재 계속 조회됨. (포럼에 문의된 상황)
-        Boolean setPrivacyInfo,
         Long id,
         String connected_at,
         Properties properties,


### PR DESCRIPTION
작업 내용
- 카카오, 구글 소셜 로그인 API 개선 적용
- Bearer 토큰 기반의 Security 인증 시스템 업데이트

참고사항
- 소셜 로그인 시, 사이드 프로젝트에서 기존에 많이 활용하던 프론트가 인가 코드를 받은 뒤에 백엔드에게 전달하는 방식이 아닌, 백엔드로 API 요청만 하면 백엔드에서 모든 걸 처리하는 방식으로 적용