### PR TITLE
feat: S3 이미지 로직 개발 및 반영

### DIFF
--- a/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
@@ -5,6 +5,7 @@ import hongik.triple.apimodule.global.common.ApplicationResponse;
 import hongik.triple.apimodule.global.security.PrincipalDetails;
 import hongik.triple.commonmodule.dto.analysis.AnalysisRes;
 import hongik.triple.commonmodule.dto.survey.SurveyRes;
+import hongik.triple.inframodule.s3.S3Client;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class AnalysisController {
 
     private final AnalysisService analysisService;
+    private final S3Client s3Client;
 
     @PostMapping("/perform")
     @Operation(summary = "피부 이미지 분석", description = "사용자에게 피부 이미지를 전달받아, 분석 결과를 조회합니다.")
@@ -69,5 +71,13 @@ public class AnalysisController {
     public ApplicationResponse<?> getAnalysisPaginationForLogPage(@RequestParam(name = "type") String acneType,
                                                                   @PageableDefault(size = 4) Pageable pageable) {
         return ApplicationResponse.ok(analysisService.getAnalysisPaginationForLogPage(acneType, pageable));
+    }
+
+    @DeleteMapping("/image")
+    @Operation(summary = "이미지 삭제", description = "S3에서 이미지를 삭제하는 API 입니다. (어드민용)")
+    public ApplicationResponse<?> delete(@RequestParam String key) {
+
+        s3Client.deleteImage(key);
+        return ApplicationResponse.ok("이미지가 삭제되었습니다.");
     }
 }

--- a/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
@@ -43,6 +43,7 @@ public class AnalysisController {
     }
 
     @GetMapping("/main")
+    @Operation(summary = "[홈화면] 피플즈 로그 썸네일 조회", description = "홈화면의 피플즈 로그에 노출되는 상위 3개의 분석 이미지를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200",
                     description = "AnceLog Main Page 에서 노출할 피부 분석 이미지 결과 목록",
@@ -56,6 +57,7 @@ public class AnalysisController {
     }
 
     @GetMapping("/my")
+    @Operation(summary = "나의 진단로그 리스트 조회", description = "나의 진단로그 페이지의 리스트를 조회합니다.")
     public ApplicationResponse<?> getAnalysisListForMyPage(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                            @RequestParam(name = "type") String acneType,
                                                            @PageableDefault(size = 4) Pageable pageable) {
@@ -63,14 +65,22 @@ public class AnalysisController {
     }
 
     @GetMapping("/detail/{analysisId}")
+    @Operation(summary = "나의 진단로그 상세페이지 조회", description = "나의 진단로그 페이지의 상세 페이지를 조회합니다.")
     public ApplicationResponse<?> getAnalysisDetail(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long analysisId) {
         return ApplicationResponse.ok(analysisService.getAnalysisDetail(principalDetails.getMember(), analysisId));
     }
 
     @GetMapping("/log")
+    @Operation(summary = "피플즈 로그 리스트 조회", description = "피플즈 로그 페이지의 리스트를 조회합니다.")
     public ApplicationResponse<?> getAnalysisPaginationForLogPage(@RequestParam(name = "type") String acneType,
                                                                   @PageableDefault(size = 4) Pageable pageable) {
         return ApplicationResponse.ok(analysisService.getAnalysisPaginationForLogPage(acneType, pageable));
+    }
+
+    @GetMapping("/log/{analysisId}")
+    @Operation(summary = "피플즈 로그 상세페이지 조회", description = "피플즈 로그 페이지의 상세 페이지를 조회합니다.")
+    public ApplicationResponse<?> getLogDetail(@PathVariable Long analysisId) {
+        return ApplicationResponse.ok(analysisService.getLogDetail(analysisId));
     }
 
     @PostMapping("/image")

--- a/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
@@ -73,6 +73,13 @@ public class AnalysisController {
         return ApplicationResponse.ok(analysisService.getAnalysisPaginationForLogPage(acneType, pageable));
     }
 
+    @PostMapping("/image")
+    @Operation(summary = "이미지 업로드", description = "S3에 이미지를 업로드하는 API 입니다. (어드민용)")
+    public ApplicationResponse<?> upload(@RequestPart MultipartFile file, @RequestParam(name = "dir") String dir) {
+
+        return ApplicationResponse.ok(s3Client.uploadImage(file, dir));
+    }
+
     @DeleteMapping("/image")
     @Operation(summary = "이미지 삭제", description = "S3에서 이미지를 삭제하는 API 입니다. (어드민용)")
     public ApplicationResponse<?> delete(@RequestParam String key) {

--- a/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/MainLogRes.java
+++ b/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/MainLogRes.java
@@ -1,0 +1,21 @@
+package hongik.triple.commonmodule.dto.analysis;
+
+import java.util.List;
+
+public record MainLogRes(
+        int comedones,
+        int pustules,
+        int papules,
+        int follicultis,
+        List<AnalysisRes> analysisRes
+) {
+    public static MainLogRes from(int comedones, int pustules, int papules, int follicultis, List<AnalysisRes> analysisRes) {
+        return new MainLogRes(
+                comedones,
+                pustules,
+                papules,
+                follicultis,
+                analysisRes
+        );
+    }
+}

--- a/common-module/src/main/java/hongik/triple/commonmodule/exception/ErrorCode.java
+++ b/common-module/src/main/java/hongik/triple/commonmodule/exception/ErrorCode.java
@@ -20,7 +20,17 @@ public enum ErrorCode {
     ALREADY_DELETE_EXCEPTION(HttpStatus.BAD_REQUEST, 2004, "이미 삭제된 리소스입니다."),
     FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, 2005, "인가되지 않는 요청입니다."),
     ALREADY_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, 2006, "이미 존재하는 리소스입니다."),
-    INVALID_SORT_EXCEPTION(HttpStatus.BAD_REQUEST, 2007, "올바르지 않은 정렬 값입니다.");
+    INVALID_SORT_EXCEPTION(HttpStatus.BAD_REQUEST, 2007, "올바르지 않은 정렬 값입니다."),
+
+    // 3000: Image Error
+    EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, 3000, "파일이 비어있습니다."),
+    INVALID_FILENAME_EXCEPTION(HttpStatus.BAD_REQUEST, 3001, "파일 이름이 유효하지 않습니다."),
+    FILE_IO_EXCEPTION(HttpStatus.BAD_REQUEST, 3002, "파일 입출력 처리 중 예상치 못한 오류가 발생했습니다."),
+    FAILED_UPLOAD_FILE(HttpStatus.INTERNAL_SERVER_ERROR, 3003, "파일 업로드에 실패하였습니다."),
+    EMPTY_S3_KEY_EXCEPTION(HttpStatus.BAD_REQUEST, 3004, "S3 key 값이 비어있습니다."),
+    NOT_FOUND_S3_EXCEPTION(HttpStatus.NOT_FOUND, 3005, "존재하지 않는 S3 객체입니다."),
+    FAILED_DELETE_FILE(HttpStatus.INTERNAL_SERVER_ERROR, 3006, "이미지 삭제에 실패하였습니다."),
+    NOT_ALLOWED_FILE_EXTENSION(HttpStatus.BAD_REQUEST, 3007, "올바르지 않은 파일 확장자입니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/domain-module/src/main/java/hongik/triple/domainmodule/domain/analysis/repository/AnalysisRepository.java
+++ b/domain-module/src/main/java/hongik/triple/domainmodule/domain/analysis/repository/AnalysisRepository.java
@@ -11,7 +11,8 @@ import java.util.List;
 public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
 
     // 메인 페이지용
-    List<Analysis> findTop3ByOrderByCreatedAtDesc();
+    List<Analysis> findTop3ByIsPublicTrueOrderByCreatedAtDesc();
+    int countByAcneTypeAndIsPublicTrue(String acneType);
 
     // 피플즈 로그 페이지용 - 전체 공개 분석 조회
     Page<Analysis> findByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);

--- a/infra-module/build.gradle
+++ b/infra-module/build.gradle
@@ -10,6 +10,12 @@ dependencies {
 
     // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // s3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.766'
+
+    // web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/infra-module/src/main/java/hongik/triple/inframodule/config/S3Config.java
+++ b/infra-module/src/main/java/hongik/triple/inframodule/config/S3Config.java
@@ -1,0 +1,34 @@
+package hongik.triple.inframodule.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+}
+

--- a/infra-module/src/main/java/hongik/triple/inframodule/s3/S3Client.java
+++ b/infra-module/src/main/java/hongik/triple/inframodule/s3/S3Client.java
@@ -1,18 +1,171 @@
 package hongik.triple.inframodule.s3;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import hongik.triple.commonmodule.exception.ApplicationException;
+import hongik.triple.commonmodule.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
 @Component
 public class S3Client {
 
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+    @Value("${cloud.aws.baseUrl}")
+    private String baseUrl;
+
+    private final AmazonS3 amazonS3;
+
     /**
-     * S3 Object에 대한 presigned URL을 생성
-     *
-     * @param fileName 파일 이름
-     * @param isUpload true면 업로드를 위한 presigned URL, false면 다운로드를 위한 presigned URL
-     * @return the presigned URL as a String
+     * 이미지 업로드
      */
-    public String getPresignedUrl(String fileName, Boolean isUpload) {
-        return null;
+    public String uploadImage(MultipartFile file, String dirName) {
+        validateFile(file);
+        validateImageExtension(file);
+
+        String key = generateFileKey(file.getOriginalFilename(), dirName);
+        ObjectMetadata metadata = createMetadata(file);
+        uploadToS3(file, key, metadata);
+
+        return key;
     }
+
+    /**
+     * 이미지 조회
+     */
+    public String getImage(String key) {
+        validateKey(key);
+        validateObjectExists(key);
+
+        return baseUrl + "/" + key;
+    }
+
+    /**
+     * 이미지 삭제
+     */
+    public void deleteImage(String key) {
+        validateKey(key);
+        validateObjectExists(key);
+
+        deleteObjectFromS3(key);
+    }
+
+    /*
+    file 유효성 검사
+     */
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ApplicationException(ErrorCode.EMPTY_FILE_EXCEPTION);
+        }
+        if (file.getOriginalFilename() == null || file.getOriginalFilename().isBlank()) {
+            throw new ApplicationException(ErrorCode.INVALID_FILENAME_EXCEPTION);
+        }
+    }
+
+    /*
+    file 확장자 검사
+     */
+    private void validateImageExtension(MultipartFile file) {
+        String originalName = file.getOriginalFilename();
+        String extension = originalName.substring(originalName.lastIndexOf('.') + 1).toLowerCase();
+
+        // 허용 확장자 목록
+        List<String> allowed = List.of("jpg", "jpeg", "png", "gif", "webp");
+
+        if (!allowed.contains(extension)) {
+            throw new ApplicationException(ErrorCode.NOT_ALLOWED_FILE_EXTENSION);
+        }
+    }
+
+    /*
+    key 생성
+     */
+    private String generateFileKey(String originalName, String dirName) {
+        String date = LocalDate.now().toString();
+        String uuid = UUID.randomUUID().toString();
+
+        return String.format("%s/%s_%s_%s", dirName, date, uuid, originalName);
+    }
+
+    /*
+    Metadata 생성
+     */
+    private ObjectMetadata createMetadata(MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+        return metadata;
+    }
+
+    /*
+    S3 업로드
+     */
+    private void uploadToS3(MultipartFile file, String key, ObjectMetadata metadata) {
+        try (InputStream input = file.getInputStream()) {
+            PutObjectRequest request = new PutObjectRequest(bucket, key, input, metadata);
+            amazonS3.putObject(request);
+
+        } catch (IOException e) {
+            throw new ApplicationException(ErrorCode.FILE_IO_EXCEPTION);
+
+        } catch (AmazonServiceException e) {
+            log.error("AWS Service 에러: {}", e.getErrorMessage());
+            throw new ApplicationException(ErrorCode.FAILED_UPLOAD_FILE);
+
+        } catch (SdkClientException e) {
+            log.error("AWS Client 에러: {}", e.getMessage());
+            throw new ApplicationException(ErrorCode.FAILED_UPLOAD_FILE);
+        }
+    }
+
+    /*
+    key 유효성 검사
+     */
+    private void validateKey(String key) {
+        if (key == null || key.isBlank()) {
+            throw new ApplicationException(ErrorCode.EMPTY_S3_KEY_EXCEPTION);
+        }
+    }
+
+    /*
+    S3 객체 유효성 검사
+     */
+    private void validateObjectExists(String key) {
+        if (!amazonS3.doesObjectExist(bucket, key)) {
+            throw new ApplicationException(ErrorCode.NOT_FOUND_S3_EXCEPTION);
+        }
+    }
+
+    /*
+    S3 이미지 객체 삭제
+     */
+    private void deleteObjectFromS3(String key) {
+        try {
+            amazonS3.deleteObject(bucket, key);
+        } catch (AmazonServiceException e) {
+            log.error("이미지 삭제 중 AWS Service 에러 발생: {}", e.getErrorMessage());
+            throw new ApplicationException(ErrorCode.FAILED_DELETE_FILE);
+        } catch (SdkClientException e) {
+            log.error("이미지 삭제 중 AWS Client 에러 발생: {}", e.getMessage());
+            throw new ApplicationException(ErrorCode.FAILED_DELETE_FILE);
+        }
+    }
+
 }


### PR DESCRIPTION
작업 내용
- S3 이미지 업로드 / 조회 / 삭제 로직 개발
- analysisController : 어드민용 이미지 업로드/삭제 API 추가
- analysisService : 이미지 업로드 및 조회 로직 전체 반영
- 피플즈로그 개별 화면 조회 API 추가 개발 -> 기존에는 토큰이 필요한 API만 존재하여 토큰 없이 조회 가능한 API를 새로 추가하였습니다.
- findTop3ByIsPublicTrueOrderByCreatedAtDesc으로 변경 -> IsPublic TRUE 조건 추가해주었습니다.
- 홈화면 피플즈로그 리턴 타입 각 여드름 개수 포함한 MainLogRes로 변경

참고사항
- application-infral.yml 수정하였습니다 -> secrets 반영 및 credentials에 올려두겠습니다.
- DB의 image_url에는 s3 key값을 저장하고, 조회 시 url 반환하도록 설정해두었습니다.


테스트 화면
<img width="848" height="612" alt="스크린샷 2025-11-20 오전 1 13 51" src="https://github.com/user-attachments/assets/867472d9-c778-4662-950a-073173b75cd0" />
<img width="854" height="593" alt="스크린샷 2025-11-20 오전 1 16 18" src="https://github.com/user-attachments/assets/b8b4cff4-bfc5-4133-acfa-0cab54a64247" />
<img width="852" height="640" alt="스크린샷 2025-11-20 오전 1 16 39" src="https://github.com/user-attachments/assets/2736fd34-d415-498a-83b9-78039f7fb948" />
