### PR TITLE
fix: 유튜브, 네이버 쇼핑 검색 키워드 변경

### DIFF
--- a/api-module/src/main/java/hongik/triple/apimodule/application/analysis/AnalysisService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/analysis/AnalysisService.java
@@ -44,12 +44,12 @@ public class AnalysisService {
 
          // 진단 결과를 기반으로 피부 관리 영상 추천 (유튜브 API)
          List<YoutubeVideoDto> videoList =
-                 youtubeClient.searchVideos(analysisData.labelToSkinType().getDescription() + " 피부 관리", 3);
+                 youtubeClient.searchVideos(analysisData.labelToSkinType().getKoreanName() + " 여드름", 3);
 
          // 진단 결과를 기반으로 맞춤형 제품 추천 (네이버 쇼핑 API)
          List<NaverProductDto> productList =
-                 naverClient.searchProducts(analysisData.labelToSkinType().getDescription() + " 피부 관리", 3);
-        
+                 naverClient.searchProducts(analysisData.labelToSkinType().getKoreanName() + " 여드름", 3);
+
          // DB 저장
          Analysis analysis = Analysis.builder()
                  .member(member)


### PR DESCRIPTION
작업 내용
- Analysis Service 수정: 기존에는 피부 타입에 대한 description을 활용해 제품을 조회하도록 하였으나, 네이버 쇼핑 API 측에서는 검색 결과가 반환되지 않는 문제 발생, 이를 해결하고자 피부 타입 검사 결과명과 여드름이라는 두 단어를 조합하여 검색하는 것으로 개선

참고사항


테스트 화면
