### PR TITLE
hotfix: 프로덕트 전반의 hotfix 반영

### DIFF
--- a/api-module/src/main/java/hongik/triple/apimodule/application/analysis/AnalysisService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/analysis/AnalysisService.java
@@ -241,6 +241,32 @@ public class AnalysisService {
         );
     }
 
+    @Transactional
+    public AnalysisRes updateIsPublic(Member member, AnalysisReq req) {
+        // Validation
+        Analysis analysis = analysisRepository.findById(req.analysisId())
+                .orElseThrow(() -> new IllegalArgumentException("Analysis not found with id: " + req.analysisId()));
+        // Analysis가 요청한 사용자의 분석 결과인지 확인
+        if(!analysis.getMember().getMemberId().equals(member.getMemberId())) {
+            throw new IllegalArgumentException("Unauthorized access to analysis with id: " + req.analysisId());
+        }
+
+        analysis.updateIsPublic(req.isPublic());
+
+        return new AnalysisRes(
+                analysis.getAnalysisId(),
+                s3Client.getImage(analysis.getImageUrl()),
+                formattedWithTime(analysis.getCreatedAt()),
+                analysis.getIsPublic(),
+                AcneType.valueOf(analysis.getAcneType()).name(),
+                AcneType.valueOf(analysis.getAcneType()).getDescription(),
+                AcneType.valueOf(analysis.getAcneType()).getCareMethod(),
+                AcneType.valueOf(analysis.getAcneType()).getGuide(),
+                analysis.getVideoData(),
+                analysis.getProductData()
+        );
+    }
+
     private String formatted(LocalDateTime time) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
         return time.format(formatter);

--- a/api-module/src/main/java/hongik/triple/apimodule/application/analysis/AnalysisService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/analysis/AnalysisService.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Service
@@ -65,6 +67,7 @@ public class AnalysisService {
          return new AnalysisRes(
                  saveAnalysis.getAnalysisId(),
                  s3Client.getImage(saveAnalysis.getImageUrl()),
+                 formatted(saveAnalysis.getCreatedAt()),
                  saveAnalysis.getIsPublic(),
                  AcneType.valueOf(saveAnalysis.getAcneType()).name(),
                  AcneType.valueOf(saveAnalysis.getAcneType()).getDescription(),
@@ -88,6 +91,7 @@ public class AnalysisService {
          return new AnalysisRes(
                  analysis.getAnalysisId(),
                  s3Client.getImage(analysis.getImageUrl()),
+                 formattedWithTime(analysis.getCreatedAt()),
                  analysis.getIsPublic(),
                  AcneType.valueOf(analysis.getAcneType()).name(),
                  AcneType.valueOf(analysis.getAcneType()).getDescription(),
@@ -110,6 +114,7 @@ public class AnalysisService {
             List<AnalysisRes> analysisList = analyses.stream().map(analysis -> new AnalysisRes(
                     analysis.getAnalysisId(),
                     s3Client.getImage(analysis.getImageUrl()),
+                    formatted(analysis.getCreatedAt()),
                     analysis.getIsPublic(),
                     AcneType.valueOf(analysis.getAcneType()).name(),
                     AcneType.valueOf(analysis.getAcneType()).getDescription(),
@@ -154,6 +159,7 @@ public class AnalysisService {
         return analysisPage.map(analysis -> new AnalysisRes(
                 analysis.getAnalysisId(),
                 s3Client.getImage(analysis.getImageUrl()),
+                formatted(analysis.getCreatedAt()),
                 analysis.getIsPublic(),
                 AcneType.valueOf(analysis.getAcneType()).name(),
                 AcneType.valueOf(analysis.getAcneType()).getDescription(),
@@ -201,6 +207,7 @@ public class AnalysisService {
         return analysisPage.map(analysis -> new AnalysisRes(
                 analysis.getAnalysisId(),
                 s3Client.getImage(analysis.getImageUrl()),
+                formatted(analysis.getCreatedAt()),
                 analysis.getIsPublic(),
                 AcneType.valueOf(analysis.getAcneType()).name(),
                 AcneType.valueOf(analysis.getAcneType()).getDescription(),
@@ -223,6 +230,7 @@ public class AnalysisService {
         return new AnalysisRes(
                 analysis.getAnalysisId(),
                 s3Client.getImage(analysis.getImageUrl()),
+                formattedWithTime(analysis.getCreatedAt()),
                 analysis.getIsPublic(),
                 AcneType.valueOf(analysis.getAcneType()).name(),
                 AcneType.valueOf(analysis.getAcneType()).getDescription(),
@@ -231,5 +239,15 @@ public class AnalysisService {
                 analysis.getVideoData(),
                 analysis.getProductData()
         );
+    }
+
+    private String formatted(LocalDateTime time) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return time.format(formatter);
+    }
+
+    private String formattedWithTime(LocalDateTime time) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        return time.format(formatter);
     }
 }

--- a/api-module/src/main/java/hongik/triple/apimodule/application/analysis/AnalysisService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/analysis/AnalysisService.java
@@ -221,15 +221,19 @@ public class AnalysisService {
     /*
     피플즈 로그 개별 화면 조회
      */
-    public AnalysisRes getLogDetail(Long analysisId) {
+    public AnalysisLogRes getLogDetail(Long analysisId) {
         // Validation
         Analysis analysis = analysisRepository.findById(analysisId)
                 .orElseThrow(() -> new IllegalArgumentException("Analysis not found with id: " + analysisId));
 
+        Member member = analysis.getMember();
+
         // Response
-        return new AnalysisRes(
+        return new AnalysisLogRes(
                 analysis.getAnalysisId(),
                 s3Client.getImage(analysis.getImageUrl()),
+                member.getName(),
+                member.getSkinType(),
                 formattedWithTime(analysis.getCreatedAt()),
                 analysis.getIsPublic(),
                 AcneType.valueOf(analysis.getAcneType()).name(),

--- a/api-module/src/main/java/hongik/triple/apimodule/application/survey/SurveyService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/survey/SurveyService.java
@@ -47,6 +47,7 @@ public class SurveyService {
                 .build();
 
         Survey savedSurvey = surveyRepository.save(survey);
+        member.updateSkinType(skinType.name()); // 유저 피부타입 세팅
 
         // Response
         return SurveyRes.builder()

--- a/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
@@ -85,6 +85,7 @@ public class AnalysisController {
     }
 
     @PatchMapping("/public")
+    @Operation(summary = "진단 기록의 공개 여부 변경", description = "자신의 진단 기록에 대한 공개 여부를 변경합니다.")
     public ApplicationResponse<?> updateIsPublic(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestBody AnalysisReq req) {

--- a/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/presentation/analysis/AnalysisController.java
@@ -3,6 +3,7 @@ package hongik.triple.apimodule.presentation.analysis;
 import hongik.triple.apimodule.application.analysis.AnalysisService;
 import hongik.triple.apimodule.global.common.ApplicationResponse;
 import hongik.triple.apimodule.global.security.PrincipalDetails;
+import hongik.triple.commonmodule.dto.analysis.AnalysisReq;
 import hongik.triple.commonmodule.dto.analysis.AnalysisRes;
 import hongik.triple.commonmodule.dto.survey.SurveyRes;
 import hongik.triple.inframodule.s3.S3Client;
@@ -81,6 +82,13 @@ public class AnalysisController {
     @Operation(summary = "피플즈 로그 상세페이지 조회", description = "피플즈 로그 페이지의 상세 페이지를 조회합니다.")
     public ApplicationResponse<?> getLogDetail(@PathVariable Long analysisId) {
         return ApplicationResponse.ok(analysisService.getLogDetail(analysisId));
+    }
+
+    @PatchMapping("/public")
+    public ApplicationResponse<?> updateIsPublic(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody AnalysisReq req) {
+        return ApplicationResponse.ok(analysisService.updateIsPublic(principalDetails.getMember(), req));
     }
 
     @PostMapping("/image")

--- a/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/AnalysisLogRes.java
+++ b/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/AnalysisLogRes.java
@@ -1,0 +1,19 @@
+package hongik.triple.commonmodule.dto.analysis;
+
+import java.util.List;
+
+public record AnalysisLogRes(
+        Long analysisId,
+        String imageUrl,
+        String userName,
+        String userSkinType,
+        String createdAt,
+        Boolean isPublic,
+        String acneType,
+        String description,
+        String careMethod,
+        String guide,
+        List<YoutubeVideoDto> videoList,
+        List<NaverProductDto> productList
+) {
+}

--- a/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/AnalysisReq.java
+++ b/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/AnalysisReq.java
@@ -1,4 +1,7 @@
 package hongik.triple.commonmodule.dto.analysis;
 
-public record AnalysisReq() {
+public record AnalysisReq(
+        Long analysisId,
+        Boolean isPublic
+) {
 }

--- a/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/AnalysisRes.java
+++ b/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/AnalysisRes.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record AnalysisRes(
         Long analysisId,
         String imageUrl,
+        String createdAt,
         Boolean isPublic,
         String acneType,
         String description,

--- a/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/MainLogRes.java
+++ b/common-module/src/main/java/hongik/triple/commonmodule/dto/analysis/MainLogRes.java
@@ -1,12 +1,14 @@
 package hongik.triple.commonmodule.dto.analysis;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record MainLogRes(
-        int comedones,
-        int pustules,
-        int papules,
-        int follicultis,
+        @JsonProperty("COMEDONES") int comedones,
+        @JsonProperty("PUSTULES") int pustules,
+        @JsonProperty("PAPULES") int papules,
+        @JsonProperty("FOLLICULITIS") int follicultis,
         List<AnalysisRes> analysisRes
 ) {
     public static MainLogRes from(int comedones, int pustules, int papules, int follicultis, List<AnalysisRes> analysisRes) {

--- a/common-module/src/main/java/hongik/triple/commonmodule/dto/member/MemberRes.java
+++ b/common-module/src/main/java/hongik/triple/commonmodule/dto/member/MemberRes.java
@@ -9,6 +9,8 @@ public record MemberRes(
         Long id,
         String email,
         String name,
+        String skinType,
+        String surveyTime,
         String profileImageUrl,
         String thumbnailImageUrl,
         String nickname,

--- a/domain-module/src/main/java/hongik/triple/domainmodule/domain/analysis/Analysis.java
+++ b/domain-module/src/main/java/hongik/triple/domainmodule/domain/analysis/Analysis.java
@@ -50,6 +50,9 @@ public class Analysis extends BaseTimeEntity {
     @Column(name = "product_data", columnDefinition = "json")
     private List<NaverProductDto> productData;
 
+    public void updateIsPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
 
     @Builder
     public Analysis(Member member,


### PR DESCRIPTION
### 작업 내용
1. 마이페이지(사이드바)에서 피부 타입 및 최근 검사일 응답값을 추가하였습니다.
2. 설문 조사 제출 시 해당 유저의 피부 타입이 새로운 설문 조사 결과에 맞게 업데이트 되도록 세팅하였습니다.
3. 피플즈로그/나의진단로그에서 필요한 검사일 응답값을 추가하고, UI 화면에 맞게 날짜 형식을 포맷팅하는 로직을 추가하였습니다.
4. 진단 후 자신의 진단결과에 대한 공개 여부를 결정하는 PATCH API 개발하였습니다.
5. 피플즈 로그 개별 화면의 유저명과 해당 유저의 피부 타입 응답값을 추가하였습니다.
