### PR TITLE
hotfix: dirty checking 문제 해결

### DIFF
--- a/api-module/src/main/java/hongik/triple/apimodule/application/survey/SurveyService.java
+++ b/api-module/src/main/java/hongik/triple/apimodule/application/survey/SurveyService.java
@@ -6,6 +6,7 @@ import hongik.triple.commonmodule.dto.survey.SurveyReq;
 import hongik.triple.commonmodule.dto.survey.SurveyRes;
 import hongik.triple.commonmodule.enumerate.SkinType;
 import hongik.triple.domainmodule.domain.member.Member;
+import hongik.triple.domainmodule.domain.member.repository.MemberRepository;
 import hongik.triple.domainmodule.domain.survey.Survey;
 import hongik.triple.domainmodule.domain.survey.repository.SurveyRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,10 +26,13 @@ import java.util.stream.Collectors;
 public class SurveyService {
 
     private final SurveyRepository surveyRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
-    public SurveyRes registerSurvey(Member member, SurveyReq request) {
+    public SurveyRes registerSurvey(Member authenticatedUser, SurveyReq request) {
         // Validation
+        Member member = memberRepository.findById(authenticatedUser.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
         validateSurveyAnswers(request.answers());
 
         // Business Logic


### PR DESCRIPTION
### 작업 내용
- 설문 조사 결과 반환 이후 해당 유저의 피부 타입을 업데이트 하는 과정에서 dirty checking이 되지 않아 업데이트가 안되는 오류 수정하였습니다.
- 준영속 상태로 전달되던 Member 객체를 DB 조회를 통해 영속 엔티티로 재조회하여 dirty checking 이루어지도록 하였습니다.